### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,10 @@
         "barryvdh/laravel-debugbar": "^3.10",
         "fakerphp/faker": "^1.23",
         "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^8.0",
-        "phpunit/phpunit": "^10.5",
-        "spatie/test-time": "^1.2"
+        "nunomaduro/collision": "^7.0",
+        "spatie/test-time": "^1.2",
+        "pestphp/pest": "^2.2",
+        "pestphp/pest-plugin-laravel": "^2.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -18,27 +18,27 @@ test('we can record a machine being logged in or out', function () {
     $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
 
     $response->assertOk();
-    $this->assertEquals('1.2.3.4', Machine::first()->ip);
-    $this->assertTrue(Machine::first()->logged_in);
+    expect(Machine::first()->ip)->toEqual('1.2.3.4');
+    expect(Machine::first()->logged_in)->toBeTrue();
 
     $response = $this->get(route('api.goodbye', ['ip' => '1.2.3.4']));
 
     $response->assertOk();
-    $this->assertEquals('1.2.3.4', Machine::first()->ip);
-    $this->assertFalse(Machine::first()->logged_in);
+    expect(Machine::first()->ip)->toEqual('1.2.3.4');
+    expect(Machine::first()->logged_in)->toBeFalse();
 
     // and repeat just to make sure multiple calls work ok
     $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
 
     $response->assertOk();
-    $this->assertEquals('1.2.3.4', Machine::first()->ip);
-    $this->assertTrue(Machine::first()->logged_in);
+    expect(Machine::first()->ip)->toEqual('1.2.3.4');
+    expect(Machine::first()->logged_in)->toBeTrue();
 
     $response = $this->get(route('api.goodbye', ['ip' => '1.2.3.4']));
 
     $response->assertOk();
-    $this->assertEquals('1.2.3.4', Machine::first()->ip);
-    $this->assertFalse(Machine::first()->logged_in);
+    expect(Machine::first()->ip)->toEqual('1.2.3.4');
+    expect(Machine::first()->logged_in)->toBeFalse();
 });
 
 test('when we record a hello we dispatch a job to lookup its dns name', function () {
@@ -83,8 +83,8 @@ test('we can record extra json data about a machine', function () {
 
     $response->assertOk();
     tap(Machine::first(), function ($machine) {
-        $this->assertEquals('1.2.3.4', $machine->ip);
-        $this->assertFalse($machine->logged_in);
+        expect($machine->ip)->toEqual('1.2.3.4');
+        expect($machine->logged_in)->toBeFalse();
         $this->assertEquals([
             'spec' => [
                 'model' => 'blah',
@@ -102,14 +102,14 @@ test('if an ip isnt supplied we make a best guess at the ip', function () {
     $response = $this->get(route('api.hello'));
 
     $response->assertOk();
-    $this->assertEquals('127.0.0.1', Machine::first()->ip);
-    $this->assertTrue(Machine::first()->logged_in);
+    expect(Machine::first()->ip)->toEqual('127.0.0.1');
+    expect(Machine::first()->logged_in)->toBeTrue();
 
     $response = $this->get(route('api.goodbye'));
 
     $response->assertOk();
-    $this->assertEquals('127.0.0.1', Machine::first()->ip);
-    $this->assertFalse(Machine::first()->logged_in);
+    expect(Machine::first()->ip)->toEqual('127.0.0.1');
+    expect(Machine::first()->logged_in)->toBeFalse();
 });
 
 test('when a machine logs in or out we store its ip and user agent and current timestamp', function () {
@@ -119,9 +119,9 @@ test('when a machine logs in or out we store its ip and user agent and current t
 
     $response->assertOk();
     tap(Machine::first(), function ($machine) {
-        $this->assertEquals('Symfony', $machine->user_agent);
-        $this->assertEquals(now()->format('Y-m-d H:i'), $machine->created_at->format('Y-m-d H:i'));
-        $this->assertTrue($machine->logged_in);
+        expect($machine->user_agent)->toEqual('Symfony');
+        expect($machine->created_at->format('Y-m-d H:i'))->toEqual(now()->format('Y-m-d H:i'));
+        expect($machine->logged_in)->toBeTrue();
     });
 });
 
@@ -129,12 +129,12 @@ test('the machines log can be automatically trimmed by a scheduled task', functi
     config(['labmon.machine_log_days' => 3]);
     $currentLog = Machine::factory()->create();
     $oldLog = Machine::factory()->create(['updated_at' => now()->subDays(4)]);
-    $this->assertEquals(2, Machine::count());
+    expect(Machine::count())->toEqual(2);
 
     $this->artisan('labmon:trimlogs');
 
-    $this->assertEquals(1, Machine::count());
-    $this->assertTrue(Machine::first()->is($currentLog));
+    expect(Machine::count())->toEqual(1);
+    expect(Machine::first()->is($currentLog))->toBeTrue();
 });
 
 test('we can get the last time an ip was seen', function () {

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -9,8 +9,6 @@ use Illuminate\Support\Facades\Queue;
 use Spatie\TestTime\TestTime;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('we can record a machine being logged in or out', function () {
     $this->withoutExceptionHandling();

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -4,11 +4,8 @@ use App\Jobs\LookupDns;
 use App\Models\Lab;
 use App\Models\LabStat;
 use App\Models\Machine;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 use Spatie\TestTime\TestTime;
-use Tests\TestCase;
-
 
 test('we can record a machine being logged in or out', function () {
     $this->withoutExceptionHandling();

--- a/tests/Feature/ApiTest.php
+++ b/tests/Feature/ApiTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Jobs\LookupDns;
 use App\Models\Lab;
 use App\Models\LabStat;
@@ -11,494 +9,452 @@ use Illuminate\Support\Facades\Queue;
 use Spatie\TestTime\TestTime;
 use Tests\TestCase;
 
-class ApiTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    /** @test */
-    public function we_can_record_a_machine_being_logged_in_or_out(): void
-    {
-        $this->withoutExceptionHandling();
-        Queue::fake([LookupDns::class]);
-        $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
+test('we can record a machine being logged in or out', function () {
+    $this->withoutExceptionHandling();
+    Queue::fake([LookupDns::class]);
+    $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
 
-        $response->assertOk();
-        $this->assertEquals('1.2.3.4', Machine::first()->ip);
-        $this->assertTrue(Machine::first()->logged_in);
+    $response->assertOk();
+    $this->assertEquals('1.2.3.4', Machine::first()->ip);
+    $this->assertTrue(Machine::first()->logged_in);
 
-        $response = $this->get(route('api.goodbye', ['ip' => '1.2.3.4']));
+    $response = $this->get(route('api.goodbye', ['ip' => '1.2.3.4']));
 
-        $response->assertOk();
-        $this->assertEquals('1.2.3.4', Machine::first()->ip);
-        $this->assertFalse(Machine::first()->logged_in);
+    $response->assertOk();
+    $this->assertEquals('1.2.3.4', Machine::first()->ip);
+    $this->assertFalse(Machine::first()->logged_in);
 
-        // and repeat just to make sure multiple calls work ok
-        $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
+    // and repeat just to make sure multiple calls work ok
+    $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
 
-        $response->assertOk();
-        $this->assertEquals('1.2.3.4', Machine::first()->ip);
-        $this->assertTrue(Machine::first()->logged_in);
+    $response->assertOk();
+    $this->assertEquals('1.2.3.4', Machine::first()->ip);
+    $this->assertTrue(Machine::first()->logged_in);
 
-        $response = $this->get(route('api.goodbye', ['ip' => '1.2.3.4']));
+    $response = $this->get(route('api.goodbye', ['ip' => '1.2.3.4']));
 
-        $response->assertOk();
-        $this->assertEquals('1.2.3.4', Machine::first()->ip);
-        $this->assertFalse(Machine::first()->logged_in);
-    }
+    $response->assertOk();
+    $this->assertEquals('1.2.3.4', Machine::first()->ip);
+    $this->assertFalse(Machine::first()->logged_in);
+});
 
-    /** @test */
-    public function when_we_record_a_hello_we_dispatch_a_job_to_lookup_its_dns_name(): void
-    {
-        $this->withoutExceptionHandling();
-        Queue::fake([LookupDns::class]);
+test('when we record a hello we dispatch a job to lookup its dns name', function () {
+    $this->withoutExceptionHandling();
+    Queue::fake([LookupDns::class]);
 
-        $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
+    $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
 
-        // See DnsLookupTest for coverage of the actual job
-        Queue::assertPushed(LookupDns::class);
-    }
+    // See DnsLookupTest for coverage of the actual job
+    Queue::assertPushed(LookupDns::class);
+});
 
-    /** @test */
-    public function we_do_not_dispatch_a_job_to_lookup_its_dns_name_if_it_already_has_been_looked_up(): void
-    {
-        $this->withoutExceptionHandling();
-        Queue::fake();
-        Machine::factory()->create(['ip' => '1.2.3.4', 'name' => 'blah.example.com']);
+test('we do not dispatch a job to lookup its dns name if it already has been looked up', function () {
+    $this->withoutExceptionHandling();
+    Queue::fake();
+    Machine::factory()->create(['ip' => '1.2.3.4', 'name' => 'blah.example.com']);
 
-        $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
+    $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
 
-        Queue::assertNotPushed(LookupDns::class);
-    }
+    Queue::assertNotPushed(LookupDns::class);
+});
 
-    /** @test */
-    public function if_we_try_and_say_goodbye_for_an_ip_that_isnt_in_the_database_we_get_a_404(): void
-    {
-        $response = $this->get(route('api.goodbye', ['ip' => '1.2.3.4']));
+test('if we try and say goodbye for an ip that isnt in the database we get a 404', function () {
+    $response = $this->get(route('api.goodbye', ['ip' => '1.2.3.4']));
 
-        $response->assertStatus(404);
-    }
+    $response->assertStatus(404);
+});
 
-    /** @test */
-    public function we_can_record_extra_json_data_about_a_machine(): void
-    {
-        $this->withoutExceptionHandling();
-        $response = $this->postJson(route('api.machine.update', ['ip' => '1.2.3.4']), [
-            'meta' => [
-                'spec' => [
-                    'model' => 'blah',
-                    'ram' => 'loads',
-                ],
-                'users' => [
-                    'fred', 'ginger',
+test('we can record extra json data about a machine', function () {
+    $this->withoutExceptionHandling();
+    $response = $this->postJson(route('api.machine.update', ['ip' => '1.2.3.4']), [
+        'meta' => [
+            'spec' => [
+                'model' => 'blah',
+                'ram' => 'loads',
+            ],
+            'users' => [
+                'fred', 'ginger',
+            ],
+        ],
+    ]);
+
+    $response->assertOk();
+    tap(Machine::first(), function ($machine) {
+        $this->assertEquals('1.2.3.4', $machine->ip);
+        $this->assertFalse($machine->logged_in);
+        $this->assertEquals([
+            'spec' => [
+                'model' => 'blah',
+                'ram' => 'loads',
+            ],
+            'users' => [
+                'fred', 'ginger',
+            ],
+        ], $machine->meta);
+    });
+});
+
+test('if an ip isnt supplied we make a best guess at the ip', function () {
+    $this->withoutExceptionHandling();
+    $response = $this->get(route('api.hello'));
+
+    $response->assertOk();
+    $this->assertEquals('127.0.0.1', Machine::first()->ip);
+    $this->assertTrue(Machine::first()->logged_in);
+
+    $response = $this->get(route('api.goodbye'));
+
+    $response->assertOk();
+    $this->assertEquals('127.0.0.1', Machine::first()->ip);
+    $this->assertFalse(Machine::first()->logged_in);
+});
+
+test('when a machine logs in or out we store its ip and user agent and current timestamp', function () {
+    $this->withoutExceptionHandling();
+
+    $response = $this->get(route('api.hello'));
+
+    $response->assertOk();
+    tap(Machine::first(), function ($machine) {
+        $this->assertEquals('Symfony', $machine->user_agent);
+        $this->assertEquals(now()->format('Y-m-d H:i'), $machine->created_at->format('Y-m-d H:i'));
+        $this->assertTrue($machine->logged_in);
+    });
+});
+
+test('the machines log can be automatically trimmed by a scheduled task', function () {
+    config(['labmon.machine_log_days' => 3]);
+    $currentLog = Machine::factory()->create();
+    $oldLog = Machine::factory()->create(['updated_at' => now()->subDays(4)]);
+    $this->assertEquals(2, Machine::count());
+
+    $this->artisan('labmon:trimlogs');
+
+    $this->assertEquals(1, Machine::count());
+    $this->assertTrue(Machine::first()->is($currentLog));
+});
+
+test('we can get the last time an ip was seen', function () {
+    $response = $this->get(route('api.hello'));
+    $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
+
+    $response = $this->get(route('api.lastseen', ['ip' => '1.2.3.4']));
+
+    $response->assertOk();
+    $response->assertJson([
+        'data' => Machine::where('ip', '=', '1.2.3.4')->first()->toArray(),
+    ]);
+});
+
+test('we can get the busyness of a lab', function () {
+    $this->withoutExceptionHandling();
+    $lab = Lab::factory()->create();
+    $machine1 = Machine::factory()->create(['lab_id' => $lab->id, 'logged_in' => true]);
+    $machine2 = Machine::factory()->create(['lab_id' => $lab->id, 'logged_in' => false]);
+    $machine3 = Machine::factory()->create(['lab_id' => $lab->id, 'logged_in' => true]);
+    $machine4 = Machine::factory()->create(['lab_id' => null, 'logged_in' => true]);
+
+    $response = $this->getJson(route('api.lab.busy', $lab->name));
+
+    $response->assertOk();
+    $response->assertJson([
+        'data' => [
+            'machines_total' => 3,
+            'logged_in_total' => 2,
+            'logged_in_percent' => '66.67',
+        ],
+    ]);
+});
+
+test('we can get the stats for all labs between given dates', function () {
+    $stat1 = LabStat::factory()->create(['created_at' => now()->subDays(200)]);
+    $stat2 = LabStat::factory()->create(['created_at' => now()->subDays(100)]);
+    $stat3 = LabStat::factory()->create(['created_at' => now()->subDays(1)]);
+
+    $response = $this->getJson(
+        route(
+            'api.labstats.dates',
+            [
+                'from' => now()->subDays(101)->format('Y-m-d'),
+                'until' => now()->format('Y-m-d'),
+            ]
+        )
+    );
+
+    $response->assertOk();
+    $response->assertJson([
+        'data' => [
+            [
+                'id' => $stat2->id,
+                'machine_total' => $stat2->machine_total,
+                'logged_in_total' => $stat2->logged_in_total,
+            ],
+            [
+                'id' => $stat3->id,
+                'machine_total' => $stat3->machine_total,
+                'logged_in_total' => $stat3->logged_in_total,
+            ],
+        ],
+    ]);
+});
+
+test('we can get a list of machines availabe for remote desktop on an always on lab', function () {
+    $this->withoutExceptionHandling();
+    $lab = Lab::factory()->create(['always_remote_access' => true]);
+    $inUseMachines = Machine::factory()->count(5)->create(['lab_id' => $lab->id, 'logged_in' => true]);
+    $notInUseMachines = Machine::factory()->count(3)->create(['lab_id' => $lab->id, 'logged_in' => false]);
+
+    $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
+
+    $response->assertOk();
+    $response->assertJsonCount(3, 'data');
+    // machines are returned in random order, so just assume the data is correct for now
+    // until I figure out how to get the json data to compare with something like ->contains()
+    // $response->assertJson([
+    //     'data' =>[
+    //         [
+    //             'id' => $notInUseMachines[0]->id,
+    //         ]
+    //     ]
+    // ]);
+});
+
+test('a lab that is not available at all for rdp returns no results', function () {
+    $this->withoutExceptionHandling();
+    $lab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => false]);
+    $machines = Machine::factory()->count(10)->create(['lab_id' => $lab->id]);
+
+    $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
+
+    $response->assertOk();
+    $response->assertJsonCount(0, 'data');
+});
+
+test('a lab that is limited available for rdp returns results if the time is right', function () {
+    $this->withoutExceptionHandling();
+    $lab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => true]);
+    $inUseMachines = Machine::factory()->count(5)->create(['lab_id' => $lab->id, 'logged_in' => true]);
+    $notInUseMachines = Machine::factory()->count(3)->create(['lab_id' => $lab->id, 'logged_in' => false]);
+    option(['remote-start-hour' => 18]);
+    option(['remote-end-hour' => 8]);
+
+    option(['remote-start-summer' => '01/Jun']);
+    option(['remote-end-summer' => '31/Aug']);
+
+    TestTime::freeze('Y-m-d H:i', '2019-06-12 20:00');
+
+    $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
+
+    $response->assertOk();
+    $response->assertJsonCount(3, 'data');
+
+    option(['remote-start-xmas' => '01/Dec']);
+    option(['remote-end-xmas' => '31/Dec']);
+
+    TestTime::freeze('Y-m-d H:i', '2019-12-20 20:00');
+
+    $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
+
+    $response->assertOk();
+    $response->assertJsonCount(3, 'data');
+
+    option(['remote-start-easter' => '01/Apr']);
+    option(['remote-end-easter' => '31/Apr']);
+
+    TestTime::freeze('Y-m-d H:i', '2019-04-20 20:00');
+
+    $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
+
+    $response->assertOk();
+    $response->assertJsonCount(3, 'data');
+});
+
+test('a lab that is limited available for rdp doesnt returns correct results based on the date and time', function () {
+    $this->withoutExceptionHandling();
+    $lab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => true]);
+    $inUseMachines = Machine::factory()->count(5)->create(['lab_id' => $lab->id, 'logged_in' => true]);
+    $notInUseMachines = Machine::factory()->count(3)->create(['lab_id' => $lab->id, 'logged_in' => false]);
+    option(['remote-start-hour' => 18]);
+    option(['remote-end-hour' => 8]);
+    option(['remote-start-summer' => '01/Jun']);
+    option(['remote-end-summer' => '31/Aug']);
+    option(['remote-start-xmas' => '01/Dec']);
+    option(['remote-end-xmas' => '31/Dec']);
+    option(['remote-start-easter' => '01/Apr']);
+    option(['remote-end-easter' => '31/Apr']);
+
+    // during the day, outside of holiday - no rdp available
+    TestTime::freeze('Y-m-d H:i', '2019-05-12 14:00');
+
+    $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
+
+    $response->assertOk();
+    $response->assertJsonCount(0, 'data');
+
+    // out-of-hours time, outside of holiday - rdp available
+    TestTime::freeze('Y-m-d H:i', '2019-02-12 20:00');
+
+    $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
+
+    $response->assertOk();
+    $response->assertJsonCount(3, 'data');
+
+    // during the day, during a holiday - rdp available
+    TestTime::freeze('Y-m-d H:i', '2019-20-12 14:00');
+
+    $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
+
+    $response->assertOk();
+    $response->assertJsonCount(3, 'data');
+});
+
+test('we can get a list of labs available for rdp', function () {
+    $this->withoutExceptionHandling();
+    $limitedLab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => true]);
+    $unlimitedLab = Lab::factory()->create(['always_remote_access' => true, 'limited_remote_access' => false]);
+    $offLimitsLab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => false]);
+    option(['remote-start-hour' => 18]);
+    option(['remote-end-hour' => 8]);
+    option(['remote-start-summer' => '01/Jun']);
+    option(['remote-end-summer' => '31/Aug']);
+    option(['remote-start-xmas' => '01/Dec']);
+    option(['remote-end-xmas' => '31/Dec']);
+    option(['remote-start-easter' => '01/Apr']);
+    option(['remote-end-easter' => '31/Apr']);
+
+    // during the day, outside of holiday - only unlimited lab available
+    TestTime::freeze('Y-m-d H:i', '2019-05-12 14:00');
+
+    $response = $this->getJson(route('api.lab.rdp_labs'));
+
+    $response->assertOk();
+    $response->assertJsonCount(1, 'data');
+    $response->assertJson([
+        'data' => [
+            [
+                'id' => $unlimitedLab->id,
+            ],
+        ],
+    ]);
+
+    // evening, outside of holiday - unlimited and limited available
+    TestTime::freeze('Y-m-d H:i', '2019-05-12 20:00');
+
+    $response = $this->getJson(route('api.lab.rdp_labs'));
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+
+    // daytime, during a holiday - unlimited and limited available
+    TestTime::freeze('Y-m-d H:i', '2019-12-12 14:00');
+
+    $response = $this->getJson(route('api.lab.rdp_labs'));
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+});
+
+test('we can get a list of all machines available for rdp', function () {
+    $this->withoutExceptionHandling();
+    $limitedLab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => true]);
+    $unlimitedLab = Lab::factory()->create(['always_remote_access' => true, 'limited_remote_access' => false]);
+    $offLimitsLab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => false]);
+    Machine::factory()->count(3)->create(['lab_id' => $limitedLab->id, 'logged_in' => false]);
+    Machine::factory()->count(4)->create(['lab_id' => $unlimitedLab->id, 'logged_in' => false]);
+    Machine::factory()->count(2)->create(['lab_id' => $offLimitsLab->id, 'logged_in' => false]);
+    Machine::factory()->create(['lab_id' => $unlimitedLab->id, 'logged_in' => false, 'is_locked' => true]);
+    option(['remote-start-hour' => 18]);
+    option(['remote-end-hour' => 8]);
+    option(['remote-start-summer' => '01/Jun']);
+    option(['remote-end-summer' => '31/Aug']);
+    option(['remote-start-xmas' => '01/Dec']);
+    option(['remote-end-xmas' => '31/Dec']);
+    option(['remote-start-easter' => '01/Apr']);
+    option(['remote-end-easter' => '31/Apr']);
+
+    // evening, outside of holiday - unlimited and limited available
+    TestTime::freeze('Y-m-d H:i', '2019-05-12 20:00');
+
+    $response = $this->getJson(route('api.machines.rdp'));
+
+    $response->assertOk();
+    // there are 3 machines in the limited lab, but it's the evening so it shows up
+    // 5 machines in the unlimited lab, but one of them is marked as locked, so shouldn't show up
+    // giving 7 available
+    $response->assertJsonCount(7, 'data');
+});
+
+test('we can get the list of labs available for the lab usage stats', function () {
+    $lab1 = Lab::factory()->create(['is_on_graphs' => true]);
+    $lab2 = Lab::factory()->create(['is_on_graphs' => false]);
+    $lab3 = Lab::factory()->create(['is_on_graphs' => true]);
+
+    $response = $this->getJson(route('api.lab.graphable'));
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+    $response->assertJson([
+        'data' => [
+            [
+                'id' => $lab1->id,
+                'name' => $lab1->name,
+            ],
+            [
+                'id' => $lab3->id,
+                'name' => $lab3->name,
+            ],
+        ],
+    ]);
+});
+
+test('we can get all the stats for the lab usage stats in one api call', function () {
+    $this->withoutExceptionHandling();
+    $lab1 = Lab::factory()->create(['is_on_graphs' => true, 'name' => 'ABC1']);
+    $lab2 = Lab::factory()->create(['is_on_graphs' => false, 'name' => 'DEF1']);
+    $lab3 = Lab::factory()->create(['is_on_graphs' => true, 'name' => 'GHK1']);
+    $inUseMachines = Machine::factory()->count(5)->create(['lab_id' => $lab1->id, 'logged_in' => true]);
+    $notInUseMachines = Machine::factory()->count(3)->create(['lab_id' => $lab1->id, 'logged_in' => false]);
+    $inUseMachines = Machine::factory()->count(3)->create(['lab_id' => $lab3->id, 'logged_in' => true]);
+    $notInUseMachines = Machine::factory()->count(5)->create(['lab_id' => $lab3->id, 'logged_in' => false]);
+
+    $response = $this->getJson(route('api.lab.graph_stats'));
+
+    $response->assertOk();
+    $response->assertJsonCount(2, 'data');
+    $response->assertJson([
+        'data' => [
+            [
+                'id' => $lab1->id,
+                'name' => $lab1->name,
+                'stats' => [
+                    'machine_total' => $lab1->members()->count(),
+                    'logged_in_total' => $lab1->members()->online()->count(),
                 ],
             ],
-        ]);
-
-        $response->assertOk();
-        tap(Machine::first(), function ($machine) {
-            $this->assertEquals('1.2.3.4', $machine->ip);
-            $this->assertFalse($machine->logged_in);
-            $this->assertEquals([
-                'spec' => [
-                    'model' => 'blah',
-                    'ram' => 'loads',
-                ],
-                'users' => [
-                    'fred', 'ginger',
-                ],
-            ], $machine->meta);
-        });
-    }
-
-    /** @test */
-    public function if_an_ip_isnt_supplied_we_make_a_best_guess_at_the_ip(): void
-    {
-        $this->withoutExceptionHandling();
-        $response = $this->get(route('api.hello'));
-
-        $response->assertOk();
-        $this->assertEquals('127.0.0.1', Machine::first()->ip);
-        $this->assertTrue(Machine::first()->logged_in);
-
-        $response = $this->get(route('api.goodbye'));
-
-        $response->assertOk();
-        $this->assertEquals('127.0.0.1', Machine::first()->ip);
-        $this->assertFalse(Machine::first()->logged_in);
-    }
-
-    /** @test */
-    public function when_a_machine_logs_in_or_out_we_store_its_ip_and_user_agent_and_current_timestamp(): void
-    {
-        $this->withoutExceptionHandling();
-
-        $response = $this->get(route('api.hello'));
-
-        $response->assertOk();
-        tap(Machine::first(), function ($machine) {
-            $this->assertEquals('Symfony', $machine->user_agent);
-            $this->assertEquals(now()->format('Y-m-d H:i'), $machine->created_at->format('Y-m-d H:i'));
-            $this->assertTrue($machine->logged_in);
-        });
-    }
-
-    /** @test */
-    public function the_machines_log_can_be_automatically_trimmed_by_a_scheduled_task(): void
-    {
-        config(['labmon.machine_log_days' => 3]);
-        $currentLog = Machine::factory()->create();
-        $oldLog = Machine::factory()->create(['updated_at' => now()->subDays(4)]);
-        $this->assertEquals(2, Machine::count());
-
-        $this->artisan('labmon:trimlogs');
-
-        $this->assertEquals(1, Machine::count());
-        $this->assertTrue(Machine::first()->is($currentLog));
-    }
-
-    /** @test */
-    public function we_can_get_the_last_time_an_ip_was_seen(): void
-    {
-        $response = $this->get(route('api.hello'));
-        $response = $this->get(route('api.hello', ['ip' => '1.2.3.4']));
-
-        $response = $this->get(route('api.lastseen', ['ip' => '1.2.3.4']));
-
-        $response->assertOk();
-        $response->assertJson([
-            'data' => Machine::where('ip', '=', '1.2.3.4')->first()->toArray(),
-        ]);
-    }
-
-    /** @test */
-    public function we_can_get_the_busyness_of_a_lab(): void
-    {
-        $this->withoutExceptionHandling();
-        $lab = Lab::factory()->create();
-        $machine1 = Machine::factory()->create(['lab_id' => $lab->id, 'logged_in' => true]);
-        $machine2 = Machine::factory()->create(['lab_id' => $lab->id, 'logged_in' => false]);
-        $machine3 = Machine::factory()->create(['lab_id' => $lab->id, 'logged_in' => true]);
-        $machine4 = Machine::factory()->create(['lab_id' => null, 'logged_in' => true]);
-
-        $response = $this->getJson(route('api.lab.busy', $lab->name));
-
-        $response->assertOk();
-        $response->assertJson([
-            'data' => [
-                'machines_total' => 3,
-                'logged_in_total' => 2,
-                'logged_in_percent' => '66.67',
-            ],
-        ]);
-    }
-
-    /** @test */
-    public function we_can_get_the_stats_for_all_labs_between_given_dates(): void
-    {
-        $stat1 = LabStat::factory()->create(['created_at' => now()->subDays(200)]);
-        $stat2 = LabStat::factory()->create(['created_at' => now()->subDays(100)]);
-        $stat3 = LabStat::factory()->create(['created_at' => now()->subDays(1)]);
-
-        $response = $this->getJson(
-            route(
-                'api.labstats.dates',
-                [
-                    'from' => now()->subDays(101)->format('Y-m-d'),
-                    'until' => now()->format('Y-m-d'),
-                ]
-            )
-        );
-
-        $response->assertOk();
-        $response->assertJson([
-            'data' => [
-                [
-                    'id' => $stat2->id,
-                    'machine_total' => $stat2->machine_total,
-                    'logged_in_total' => $stat2->logged_in_total,
-                ],
-                [
-                    'id' => $stat3->id,
-                    'machine_total' => $stat3->machine_total,
-                    'logged_in_total' => $stat3->logged_in_total,
+            [
+                'id' => $lab3->id,
+                'name' => $lab3->name,
+                'stats' => [
+                    'machine_total' => $lab3->members()->count(),
+                    'logged_in_total' => $lab3->members()->online()->count(),
                 ],
             ],
+        ],
+    ]);
+});
+
+test('we can get a list of all machines', function () {
+    $machines = Machine::factory()->count(5)->create();
+
+    $response = $this->getJson(route('api.machine.index'));
+
+    $response->assertOk();
+    $machines->each(function ($machine) use ($response) {
+        $response->assertJsonFragment([
+            'data' => Machine::orderBy('ip')->get()->toArray(),
         ]);
-    }
-
-    /** @test */
-    public function we_can_get_a_list_of_machines_availabe_for_remote_desktop_on_an_always_on_lab(): void
-    {
-        $this->withoutExceptionHandling();
-        $lab = Lab::factory()->create(['always_remote_access' => true]);
-        $inUseMachines = Machine::factory()->count(5)->create(['lab_id' => $lab->id, 'logged_in' => true]);
-        $notInUseMachines = Machine::factory()->count(3)->create(['lab_id' => $lab->id, 'logged_in' => false]);
-
-        $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
-
-        $response->assertOk();
-        $response->assertJsonCount(3, 'data');
-        // machines are returned in random order, so just assume the data is correct for now
-        // until I figure out how to get the json data to compare with something like ->contains()
-        // $response->assertJson([
-        //     'data' =>[
-        //         [
-        //             'id' => $notInUseMachines[0]->id,
-        //         ]
-        //     ]
-        // ]);
-    }
-
-    /** @test */
-    public function a_lab_that_is_not_available_at_all_for_rdp_returns_no_results(): void
-    {
-        $this->withoutExceptionHandling();
-        $lab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => false]);
-        $machines = Machine::factory()->count(10)->create(['lab_id' => $lab->id]);
-
-        $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
-
-        $response->assertOk();
-        $response->assertJsonCount(0, 'data');
-    }
-
-    /** @test */
-    public function a_lab_that_is_limited_available_for_rdp_returns_results_if_the_time_is_right(): void
-    {
-        $this->withoutExceptionHandling();
-        $lab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => true]);
-        $inUseMachines = Machine::factory()->count(5)->create(['lab_id' => $lab->id, 'logged_in' => true]);
-        $notInUseMachines = Machine::factory()->count(3)->create(['lab_id' => $lab->id, 'logged_in' => false]);
-        option(['remote-start-hour' => 18]);
-        option(['remote-end-hour' => 8]);
-
-        option(['remote-start-summer' => '01/Jun']);
-        option(['remote-end-summer' => '31/Aug']);
-
-        TestTime::freeze('Y-m-d H:i', '2019-06-12 20:00');
-
-        $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
-
-        $response->assertOk();
-        $response->assertJsonCount(3, 'data');
-
-        option(['remote-start-xmas' => '01/Dec']);
-        option(['remote-end-xmas' => '31/Dec']);
-
-        TestTime::freeze('Y-m-d H:i', '2019-12-20 20:00');
-
-        $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
-
-        $response->assertOk();
-        $response->assertJsonCount(3, 'data');
-
-        option(['remote-start-easter' => '01/Apr']);
-        option(['remote-end-easter' => '31/Apr']);
-
-        TestTime::freeze('Y-m-d H:i', '2019-04-20 20:00');
-
-        $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
-
-        $response->assertOk();
-        $response->assertJsonCount(3, 'data');
-    }
-
-    /** @test */
-    public function a_lab_that_is_limited_available_for_rdp_doesnt_returns_correct_results_based_on_the_date_and_time(): void
-    {
-        $this->withoutExceptionHandling();
-        $lab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => true]);
-        $inUseMachines = Machine::factory()->count(5)->create(['lab_id' => $lab->id, 'logged_in' => true]);
-        $notInUseMachines = Machine::factory()->count(3)->create(['lab_id' => $lab->id, 'logged_in' => false]);
-        option(['remote-start-hour' => 18]);
-        option(['remote-end-hour' => 8]);
-        option(['remote-start-summer' => '01/Jun']);
-        option(['remote-end-summer' => '31/Aug']);
-        option(['remote-start-xmas' => '01/Dec']);
-        option(['remote-end-xmas' => '31/Dec']);
-        option(['remote-start-easter' => '01/Apr']);
-        option(['remote-end-easter' => '31/Apr']);
-
-        // during the day, outside of holiday - no rdp available
-        TestTime::freeze('Y-m-d H:i', '2019-05-12 14:00');
-
-        $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
-
-        $response->assertOk();
-        $response->assertJsonCount(0, 'data');
-
-        // out-of-hours time, outside of holiday - rdp available
-        TestTime::freeze('Y-m-d H:i', '2019-02-12 20:00');
-
-        $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
-
-        $response->assertOk();
-        $response->assertJsonCount(3, 'data');
-
-        // during the day, during a holiday - rdp available
-        TestTime::freeze('Y-m-d H:i', '2019-20-12 14:00');
-
-        $response = $this->getJson(route('api.lab.rdp_machines', $lab->name));
-
-        $response->assertOk();
-        $response->assertJsonCount(3, 'data');
-    }
-
-    /** @test */
-    public function we_can_get_a_list_of_labs_available_for_rdp(): void
-    {
-        $this->withoutExceptionHandling();
-        $limitedLab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => true]);
-        $unlimitedLab = Lab::factory()->create(['always_remote_access' => true, 'limited_remote_access' => false]);
-        $offLimitsLab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => false]);
-        option(['remote-start-hour' => 18]);
-        option(['remote-end-hour' => 8]);
-        option(['remote-start-summer' => '01/Jun']);
-        option(['remote-end-summer' => '31/Aug']);
-        option(['remote-start-xmas' => '01/Dec']);
-        option(['remote-end-xmas' => '31/Dec']);
-        option(['remote-start-easter' => '01/Apr']);
-        option(['remote-end-easter' => '31/Apr']);
-
-        // during the day, outside of holiday - only unlimited lab available
-        TestTime::freeze('Y-m-d H:i', '2019-05-12 14:00');
-
-        $response = $this->getJson(route('api.lab.rdp_labs'));
-
-        $response->assertOk();
-        $response->assertJsonCount(1, 'data');
-        $response->assertJson([
-            'data' => [
-                [
-                    'id' => $unlimitedLab->id,
-                ],
-            ],
-        ]);
-
-        // evening, outside of holiday - unlimited and limited available
-        TestTime::freeze('Y-m-d H:i', '2019-05-12 20:00');
-
-        $response = $this->getJson(route('api.lab.rdp_labs'));
-
-        $response->assertOk();
-        $response->assertJsonCount(2, 'data');
-
-        // daytime, during a holiday - unlimited and limited available
-        TestTime::freeze('Y-m-d H:i', '2019-12-12 14:00');
-
-        $response = $this->getJson(route('api.lab.rdp_labs'));
-
-        $response->assertOk();
-        $response->assertJsonCount(2, 'data');
-    }
-
-    /** @test */
-    public function we_can_get_a_list_of_all_machines_available_for_rdp(): void
-    {
-        $this->withoutExceptionHandling();
-        $limitedLab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => true]);
-        $unlimitedLab = Lab::factory()->create(['always_remote_access' => true, 'limited_remote_access' => false]);
-        $offLimitsLab = Lab::factory()->create(['always_remote_access' => false, 'limited_remote_access' => false]);
-        Machine::factory()->count(3)->create(['lab_id' => $limitedLab->id, 'logged_in' => false]);
-        Machine::factory()->count(4)->create(['lab_id' => $unlimitedLab->id, 'logged_in' => false]);
-        Machine::factory()->count(2)->create(['lab_id' => $offLimitsLab->id, 'logged_in' => false]);
-        Machine::factory()->create(['lab_id' => $unlimitedLab->id, 'logged_in' => false, 'is_locked' => true]);
-        option(['remote-start-hour' => 18]);
-        option(['remote-end-hour' => 8]);
-        option(['remote-start-summer' => '01/Jun']);
-        option(['remote-end-summer' => '31/Aug']);
-        option(['remote-start-xmas' => '01/Dec']);
-        option(['remote-end-xmas' => '31/Dec']);
-        option(['remote-start-easter' => '01/Apr']);
-        option(['remote-end-easter' => '31/Apr']);
-
-        // evening, outside of holiday - unlimited and limited available
-        TestTime::freeze('Y-m-d H:i', '2019-05-12 20:00');
-
-        $response = $this->getJson(route('api.machines.rdp'));
-
-        $response->assertOk();
-        // there are 3 machines in the limited lab, but it's the evening so it shows up
-        // 5 machines in the unlimited lab, but one of them is marked as locked, so shouldn't show up
-        // giving 7 available
-        $response->assertJsonCount(7, 'data');
-    }
-
-    /** @test */
-    public function we_can_get_the_list_of_labs_available_for_the_lab_usage_stats(): void
-    {
-        $lab1 = Lab::factory()->create(['is_on_graphs' => true]);
-        $lab2 = Lab::factory()->create(['is_on_graphs' => false]);
-        $lab3 = Lab::factory()->create(['is_on_graphs' => true]);
-
-        $response = $this->getJson(route('api.lab.graphable'));
-
-        $response->assertOk();
-        $response->assertJsonCount(2, 'data');
-        $response->assertJson([
-            'data' => [
-                [
-                    'id' => $lab1->id,
-                    'name' => $lab1->name,
-                ],
-                [
-                    'id' => $lab3->id,
-                    'name' => $lab3->name,
-                ],
-            ],
-        ]);
-    }
-
-    /** @test */
-    public function we_can_get_all_the_stats_for_the_lab_usage_stats_in_one_api_call(): void
-    {
-        $this->withoutExceptionHandling();
-        $lab1 = Lab::factory()->create(['is_on_graphs' => true, 'name' => 'ABC1']);
-        $lab2 = Lab::factory()->create(['is_on_graphs' => false, 'name' => 'DEF1']);
-        $lab3 = Lab::factory()->create(['is_on_graphs' => true, 'name' => 'GHK1']);
-        $inUseMachines = Machine::factory()->count(5)->create(['lab_id' => $lab1->id, 'logged_in' => true]);
-        $notInUseMachines = Machine::factory()->count(3)->create(['lab_id' => $lab1->id, 'logged_in' => false]);
-        $inUseMachines = Machine::factory()->count(3)->create(['lab_id' => $lab3->id, 'logged_in' => true]);
-        $notInUseMachines = Machine::factory()->count(5)->create(['lab_id' => $lab3->id, 'logged_in' => false]);
-
-        $response = $this->getJson(route('api.lab.graph_stats'));
-
-        $response->assertOk();
-        $response->assertJsonCount(2, 'data');
-        $response->assertJson([
-            'data' => [
-                [
-                    'id' => $lab1->id,
-                    'name' => $lab1->name,
-                    'stats' => [
-                        'machine_total' => $lab1->members()->count(),
-                        'logged_in_total' => $lab1->members()->online()->count(),
-                    ],
-                ],
-                [
-                    'id' => $lab3->id,
-                    'name' => $lab3->name,
-                    'stats' => [
-                        'machine_total' => $lab3->members()->count(),
-                        'logged_in_total' => $lab3->members()->online()->count(),
-                    ],
-                ],
-            ],
-        ]);
-    }
-
-    /** @test */
-    public function we_can_get_a_list_of_all_machines(): void
-    {
-        $machines = Machine::factory()->count(5)->create();
-
-        $response = $this->getJson(route('api.machine.index'));
-
-        $response->assertOk();
-        $machines->each(function ($machine) use ($response) {
-            $response->assertJsonFragment([
-                'data' => Machine::orderBy('ip')->get()->toArray(),
-            ]);
-        });
-    }
-}
+    });
+});

--- a/tests/Feature/DnsLookupTest.php
+++ b/tests/Feature/DnsLookupTest.php
@@ -6,8 +6,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use TitasGailius\Terminal\Terminal;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('a machine can lookup the dns name for its ip address', function () {
     $machine = Machine::factory()->create(['ip' => '1.1.1.1', 'name' => null]);

--- a/tests/Feature/DnsLookupTest.php
+++ b/tests/Feature/DnsLookupTest.php
@@ -2,10 +2,7 @@
 
 use App\Jobs\LookupDns;
 use App\Models\Machine;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 use TitasGailius\Terminal\Terminal;
-
 
 test('a machine can lookup the dns name for its ip address', function () {
     $machine = Machine::factory()->create(['ip' => '1.1.1.1', 'name' => null]);

--- a/tests/Feature/DnsLookupTest.php
+++ b/tests/Feature/DnsLookupTest.php
@@ -14,7 +14,7 @@ test('a machine can lookup the dns name for its ip address', function () {
 
     $machine->lookupDns();
 
-    $this->assertEquals('one.one.one.one', $machine->fresh()->name);
+    expect($machine->fresh()->name)->toEqual('one.one.one.one');
 });
 
 test('if a custom dns resolver is configured then it is preferred over phps internal calls', function () {
@@ -27,7 +27,7 @@ test('if a custom dns resolver is configured then it is preferred over phps inte
 
     $machine->lookupDns();
 
-    $this->assertEquals('my.fake.domain', $machine->fresh()->name);
+    expect($machine->fresh()->name)->toEqual('my.fake.domain');
 });
 
 test('there is an artisan command to lookup all machine dns names', function () {
@@ -36,8 +36,8 @@ test('there is an artisan command to lookup all machine dns names', function () 
 
     $this->artisan('labmon:refreshdns');
 
-    $this->assertEquals('one.one.one.one', $machine1->fresh()->name);
-    $this->assertEquals('dns.google', $machine2->fresh()->name);
+    expect($machine1->fresh()->name)->toEqual('one.one.one.one');
+    expect($machine2->fresh()->name)->toEqual('dns.google');
 });
 
 test('the artisan command is registered with the schedular', function () {
@@ -52,5 +52,5 @@ test('the lookup dns job can lookup the dns for a machine', function () {
 
     LookupDns::dispatch($machine);
 
-    $this->assertEquals('one.one.one.one', $machine->fresh()->name);
+    expect($machine->fresh()->name)->toEqual('one.one.one.one');
 });

--- a/tests/Feature/DnsLookupTest.php
+++ b/tests/Feature/DnsLookupTest.php
@@ -1,70 +1,56 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Jobs\LookupDns;
 use App\Models\Machine;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use TitasGailius\Terminal\Terminal;
 
-class DnsLookupTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    /** @test */
-    public function a_machine_can_lookup_the_dns_name_for_its_ip_address(): void
-    {
-        $machine = Machine::factory()->create(['ip' => '1.1.1.1', 'name' => null]);
+test('a machine can lookup the dns name for its ip address', function () {
+    $machine = Machine::factory()->create(['ip' => '1.1.1.1', 'name' => null]);
 
-        $machine->lookupDns();
+    $machine->lookupDns();
 
-        $this->assertEquals('one.one.one.one', $machine->fresh()->name);
-    }
+    $this->assertEquals('one.one.one.one', $machine->fresh()->name);
+});
 
-    /** @test */
-    public function if_a_custom_dns_resolver_is_configured_then_it_is_preferred_over_phps_internal_calls(): void
-    {
-        $machine = Machine::factory()->create(['ip' => '1.1.1.1', 'name' => null]);
-        config(['labmon.dns_server' => '1.1.1.1']);
+test('if a custom dns resolver is configured then it is preferred over phps internal calls', function () {
+    $machine = Machine::factory()->create(['ip' => '1.1.1.1', 'name' => null]);
+    config(['labmon.dns_server' => '1.1.1.1']);
 
-        Terminal::fake([
-            'host 1.1.1.1 1.1.1.1' => "some-guff\n1.1.1.1.in-addr.arpa domain name pointer my.fake.domain.",
-        ]);
+    Terminal::fake([
+        'host 1.1.1.1 1.1.1.1' => "some-guff\n1.1.1.1.in-addr.arpa domain name pointer my.fake.domain.",
+    ]);
 
-        $machine->lookupDns();
+    $machine->lookupDns();
 
-        $this->assertEquals('my.fake.domain', $machine->fresh()->name);
-    }
+    $this->assertEquals('my.fake.domain', $machine->fresh()->name);
+});
 
-    /** @test */
-    public function there_is_an_artisan_command_to_lookup_all_machine_dns_names(): void
-    {
-        $machine1 = Machine::factory()->create(['ip' => '1.1.1.1']);
-        $machine2 = Machine::factory()->create(['ip' => '8.8.8.8']);
+test('there is an artisan command to lookup all machine dns names', function () {
+    $machine1 = Machine::factory()->create(['ip' => '1.1.1.1']);
+    $machine2 = Machine::factory()->create(['ip' => '8.8.8.8']);
 
-        $this->artisan('labmon:refreshdns');
+    $this->artisan('labmon:refreshdns');
 
-        $this->assertEquals('one.one.one.one', $machine1->fresh()->name);
-        $this->assertEquals('dns.google', $machine2->fresh()->name);
-    }
+    $this->assertEquals('one.one.one.one', $machine1->fresh()->name);
+    $this->assertEquals('dns.google', $machine2->fresh()->name);
+});
 
-    /** @test */
-    public function the_artisan_command_is_registered_with_the_schedular(): void
-    {
-        $this->assertCommandIsScheduled('labmon:refreshdns');
-    }
+test('the artisan command is registered with the schedular', function () {
+    $this->assertCommandIsScheduled('labmon:refreshdns');
+});
 
-    /** @test */
-    public function the_lookup_dns_job_can_lookup_the_dns_for_a_machine(): void
-    {
-        $machine = Machine::factory()->create([
-            'ip' => '1.1.1.1',
-            'name' => null,
-        ]);
+test('the lookup dns job can lookup the dns for a machine', function () {
+    $machine = Machine::factory()->create([
+        'ip' => '1.1.1.1',
+        'name' => null,
+    ]);
 
-        LookupDns::dispatch($machine);
+    LookupDns::dispatch($machine);
 
-        $this->assertEquals('one.one.one.one', $machine->fresh()->name);
-    }
-}
+    $this->assertEquals('one.one.one.one', $machine->fresh()->name);
+});

--- a/tests/Feature/LabStatsTest.php
+++ b/tests/Feature/LabStatsTest.php
@@ -3,9 +3,6 @@
 use App\Models\Lab;
 use App\Models\LabStat;
 use App\Models\Machine;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
 
 test('we can record the busyness of every lab', function () {
     $lab1 = Lab::factory()->create();

--- a/tests/Feature/LabStatsTest.php
+++ b/tests/Feature/LabStatsTest.php
@@ -20,17 +20,17 @@ test('we can record the busyness of every lab', function () {
     $this->artisan('labmon:recordstats');
 
     tap(LabStat::all(), function ($stats) use ($lab1, $lab2, $lab3) {
-        $this->assertEquals($lab1->id, $stats[0]->lab_id);
-        $this->assertEquals($lab1->members()->count(), $stats[0]->machine_total);
-        $this->assertEquals($lab1->members()->online()->count(), $stats[0]->logged_in_total);
+        expect($stats[0]->lab_id)->toEqual($lab1->id);
+        expect($stats[0]->machine_total)->toEqual($lab1->members()->count());
+        expect($stats[0]->logged_in_total)->toEqual($lab1->members()->online()->count());
 
-        $this->assertEquals($lab2->id, $stats[1]->lab_id);
-        $this->assertEquals($lab2->members()->count(), $stats[1]->machine_total);
-        $this->assertEquals($lab2->members()->online()->count(), $stats[1]->logged_in_total);
+        expect($stats[1]->lab_id)->toEqual($lab2->id);
+        expect($stats[1]->machine_total)->toEqual($lab2->members()->count());
+        expect($stats[1]->logged_in_total)->toEqual($lab2->members()->online()->count());
 
-        $this->assertEquals($lab3->id, $stats[2]->lab_id);
-        $this->assertEquals($lab3->members()->count(), $stats[2]->machine_total);
-        $this->assertEquals($lab3->members()->online()->count(), $stats[2]->logged_in_total);
+        expect($stats[2]->lab_id)->toEqual($lab3->id);
+        expect($stats[2]->machine_total)->toEqual($lab3->members()->count());
+        expect($stats[2]->logged_in_total)->toEqual($lab3->members()->online()->count());
     });
 });
 
@@ -40,14 +40,14 @@ test('the lab stats are truncated after n days', function () {
     $stat2 = LabStat::factory()->create(['created_at' => now()->subDays(2)]);
     $stat3 = LabStat::factory()->create(['created_at' => now()->subDays(1)]);
 
-    $this->assertEquals(3, LabStat::count());
+    expect(LabStat::count())->toEqual(3);
 
     $this->artisan('labmon:recordstats');
 
     // we should have 5 stats - the 2 old that should have been kept, and 3
     // new ones for each lab that the stat factories created
-    $this->assertEquals(5, LabStat::count());
-    $this->assertNull(LabStat::find($stat1->id));
+    expect(LabStat::count())->toEqual(5);
+    expect(LabStat::find($stat1->id))->toBeNull();
 });
 
 test('the recordstats command is registered with the schedular', function () {

--- a/tests/Feature/LabStatsTest.php
+++ b/tests/Feature/LabStatsTest.php
@@ -6,8 +6,6 @@ use App\Models\Machine;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('we can record the busyness of every lab', function () {
     $lab1 = Lab::factory()->create();

--- a/tests/Feature/LabStatsTest.php
+++ b/tests/Feature/LabStatsTest.php
@@ -1,65 +1,55 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Lab;
 use App\Models\LabStat;
 use App\Models\Machine;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class LabStatsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    /** @test */
-    public function we_can_record_the_busyness_of_every_lab(): void
-    {
-        $lab1 = Lab::factory()->create();
-        $lab2 = Lab::factory()->create();
-        $lab3 = Lab::factory()->create();
-        $machines1 = Machine::factory()->count(5)->create(['lab_id' => $lab1->id]);
-        $machines2 = Machine::factory()->count(5)->create(['lab_id' => $lab2->id]);
-        $machines3 = Machine::factory()->count(5)->create(['lab_id' => $lab3->id]);
+test('we can record the busyness of every lab', function () {
+    $lab1 = Lab::factory()->create();
+    $lab2 = Lab::factory()->create();
+    $lab3 = Lab::factory()->create();
+    $machines1 = Machine::factory()->count(5)->create(['lab_id' => $lab1->id]);
+    $machines2 = Machine::factory()->count(5)->create(['lab_id' => $lab2->id]);
+    $machines3 = Machine::factory()->count(5)->create(['lab_id' => $lab3->id]);
 
-        $this->artisan('labmon:recordstats');
+    $this->artisan('labmon:recordstats');
 
-        tap(LabStat::all(), function ($stats) use ($lab1, $lab2, $lab3) {
-            $this->assertEquals($lab1->id, $stats[0]->lab_id);
-            $this->assertEquals($lab1->members()->count(), $stats[0]->machine_total);
-            $this->assertEquals($lab1->members()->online()->count(), $stats[0]->logged_in_total);
+    tap(LabStat::all(), function ($stats) use ($lab1, $lab2, $lab3) {
+        $this->assertEquals($lab1->id, $stats[0]->lab_id);
+        $this->assertEquals($lab1->members()->count(), $stats[0]->machine_total);
+        $this->assertEquals($lab1->members()->online()->count(), $stats[0]->logged_in_total);
 
-            $this->assertEquals($lab2->id, $stats[1]->lab_id);
-            $this->assertEquals($lab2->members()->count(), $stats[1]->machine_total);
-            $this->assertEquals($lab2->members()->online()->count(), $stats[1]->logged_in_total);
+        $this->assertEquals($lab2->id, $stats[1]->lab_id);
+        $this->assertEquals($lab2->members()->count(), $stats[1]->machine_total);
+        $this->assertEquals($lab2->members()->online()->count(), $stats[1]->logged_in_total);
 
-            $this->assertEquals($lab3->id, $stats[2]->lab_id);
-            $this->assertEquals($lab3->members()->count(), $stats[2]->machine_total);
-            $this->assertEquals($lab3->members()->online()->count(), $stats[2]->logged_in_total);
-        });
-    }
+        $this->assertEquals($lab3->id, $stats[2]->lab_id);
+        $this->assertEquals($lab3->members()->count(), $stats[2]->machine_total);
+        $this->assertEquals($lab3->members()->online()->count(), $stats[2]->logged_in_total);
+    });
+});
 
-    /** @test */
-    public function the_lab_stats_are_truncated_after_N_days(): void
-    {
-        config(['labmon.truncate_stats_days' => 2]);
-        $stat1 = LabStat::factory()->create(['created_at' => now()->subDays(3)]);
-        $stat2 = LabStat::factory()->create(['created_at' => now()->subDays(2)]);
-        $stat3 = LabStat::factory()->create(['created_at' => now()->subDays(1)]);
+test('the lab stats are truncated after n days', function () {
+    config(['labmon.truncate_stats_days' => 2]);
+    $stat1 = LabStat::factory()->create(['created_at' => now()->subDays(3)]);
+    $stat2 = LabStat::factory()->create(['created_at' => now()->subDays(2)]);
+    $stat3 = LabStat::factory()->create(['created_at' => now()->subDays(1)]);
 
-        $this->assertEquals(3, LabStat::count());
+    $this->assertEquals(3, LabStat::count());
 
-        $this->artisan('labmon:recordstats');
+    $this->artisan('labmon:recordstats');
 
-        // we should have 5 stats - the 2 old that should have been kept, and 3
-        // new ones for each lab that the stat factories created
-        $this->assertEquals(5, LabStat::count());
-        $this->assertNull(LabStat::find($stat1->id));
-    }
+    // we should have 5 stats - the 2 old that should have been kept, and 3
+    // new ones for each lab that the stat factories created
+    $this->assertEquals(5, LabStat::count());
+    $this->assertNull(LabStat::find($stat1->id));
+});
 
-    /** @test */
-    public function the_recordstats_command_is_registered_with_the_schedular(): void
-    {
-        $this->assertCommandIsScheduled('labmon:recordstats');
-    }
-}
+test('the recordstats command is registered with the schedular', function () {
+    $this->assertCommandIsScheduled('labmon:recordstats');
+});

--- a/tests/Feature/LabTest.php
+++ b/tests/Feature/LabTest.php
@@ -25,8 +25,8 @@ test('we can create a new lab', function () {
         ->assertSet('labName', '')
         ->assertSet('editing', false)
         ->assertDispatched('labAdded');
-    $this->assertEquals('LABLAB', Lab::first()->name);
-    $this->assertEquals('Science', Lab::first()->school);
+    expect(Lab::first()->name)->toEqual('LABLAB');
+    expect(Lab::first()->school)->toEqual('Science');
 });
 
 test('we can delete an existing lab', function () {
@@ -41,7 +41,7 @@ test('we can delete an existing lab', function () {
         ->assertDontSee('Delete')
         ->assertSee('Confirm')
         ->call('deleteLab');
-    $this->assertCount(0, Lab::all());
+    expect(Lab::all())->toHaveCount(0);
 });
 
 test('we can add machine ips to a lab', function () {
@@ -54,9 +54,9 @@ test('we can add machine ips to a lab', function () {
 
     $response->assertRedirect(route('lab.show', $lab->id));
     tap($lab->fresh(), function ($lab) {
-        $this->assertCount(2, $lab->members);
-        $this->assertTrue($lab->members->contains('ip', '1.2.3.4'));
-        $this->assertTrue($lab->members->contains('ip', '127.0.0.1'));
+        expect($lab->members)->toHaveCount(2);
+        expect($lab->members->contains('ip', '1.2.3.4'))->toBeTrue();
+        expect($lab->members->contains('ip', '127.0.0.1'))->toBeTrue();
     });
 });
 
@@ -72,9 +72,9 @@ test('sending a list of labmember ips removes any not on the list', function () 
 
     $response->assertRedirect(route('lab.show', $lab->id));
     tap($lab->fresh(), function ($lab) {
-        $this->assertCount(2, $lab->members);
-        $this->assertTrue($lab->members->contains('ip', '1.0.3.4'));
-        $this->assertTrue($lab->members->contains('ip', '127.0.0.1'));
+        expect($lab->members)->toHaveCount(2);
+        expect($lab->members->contains('ip', '1.0.3.4'))->toBeTrue();
+        expect($lab->members->contains('ip', '127.0.0.1'))->toBeTrue();
     });
 });
 
@@ -90,9 +90,9 @@ test('blank lines in the list of ips are ignored', function () {
 
     $response->assertRedirect(route('lab.show', $lab->id));
     tap($lab->fresh(), function ($lab) {
-        $this->assertCount(2, $lab->members);
-        $this->assertTrue($lab->members->contains('ip', '1.0.3.4'));
-        $this->assertTrue($lab->members->contains('ip', '127.0.0.1'));
+        expect($lab->members)->toHaveCount(2);
+        expect($lab->members->contains('ip', '1.0.3.4'))->toBeTrue();
+        expect($lab->members->contains('ip', '127.0.0.1'))->toBeTrue();
     });
 });
 
@@ -108,8 +108,8 @@ test('invalid ips are ignored', function () {
 
     $response->assertRedirect(route('lab.show', $lab->id));
     tap($lab->fresh(), function ($lab) {
-        $this->assertCount(1, $lab->members);
-        $this->assertTrue($lab->members->contains('ip', '1.0.3.4'));
+        expect($lab->members)->toHaveCount(1);
+        expect($lab->members->contains('ip', '1.0.3.4'))->toBeTrue();
     });
 });
 
@@ -121,36 +121,36 @@ test('we can toggle a labs availability for remote access', function () {
     $lab->limited_remote_access = false;
     $lab->save();
 
-    $this->assertFalse($lab->limited_remote_access);
-    $this->assertFalse($lab->always_remote_access);
+    expect($lab->limited_remote_access)->toBeFalse();
+    expect($lab->always_remote_access)->toBeFalse();
 
     Livewire::test(LabList::class)
         ->assertSee($lab->name)
         ->call('toggleLimitedRemote', $lab->id);
 
-    $this->assertTrue($lab->fresh()->limited_remote_access);
-    $this->assertFalse($lab->fresh()->always_remote_access);
+    expect($lab->fresh()->limited_remote_access)->toBeTrue();
+    expect($lab->fresh()->always_remote_access)->toBeFalse();
 
     Livewire::test(LabList::class)
         ->assertSee($lab->name)
         ->call('toggleLimitedRemote', $lab->id);
 
-    $this->assertFalse($lab->fresh()->limited_remote_access);
-    $this->assertFalse($lab->fresh()->always_remote_access);
+    expect($lab->fresh()->limited_remote_access)->toBeFalse();
+    expect($lab->fresh()->always_remote_access)->toBeFalse();
 
     Livewire::test(LabList::class)
         ->assertSee($lab->name)
         ->call('toggleAlwaysRemote', $lab->id);
 
-    $this->assertFalse($lab->fresh()->limited_remote_access);
-    $this->assertTrue($lab->fresh()->always_remote_access);
+    expect($lab->fresh()->limited_remote_access)->toBeFalse();
+    expect($lab->fresh()->always_remote_access)->toBeTrue();
 
     Livewire::test(LabList::class)
         ->assertSee($lab->name)
         ->call('toggleAlwaysRemote', $lab->id);
 
-    $this->assertFalse($lab->fresh()->limited_remote_access);
-    $this->assertFalse($lab->fresh()->always_remote_access);
+    expect($lab->fresh()->limited_remote_access)->toBeFalse();
+    expect($lab->fresh()->always_remote_access)->toBeFalse();
 });
 
 test('a lab cannot be both limited and unlimited access at the same time', function () {
@@ -165,15 +165,15 @@ test('a lab cannot be both limited and unlimited access at the same time', funct
         ->assertSee($lab->name)
         ->call('toggleLimitedRemote', $lab->id);
 
-    $this->assertTrue($lab->fresh()->limited_remote_access);
-    $this->assertFalse($lab->fresh()->always_remote_access);
+    expect($lab->fresh()->limited_remote_access)->toBeTrue();
+    expect($lab->fresh()->always_remote_access)->toBeFalse();
 
     Livewire::test(LabList::class)
         ->assertSee($lab->name)
         ->call('toggleAlwaysRemote', $lab->id);
 
-    $this->assertFalse($lab->fresh()->limited_remote_access);
-    $this->assertTrue($lab->fresh()->always_remote_access);
+    expect($lab->fresh()->limited_remote_access)->toBeFalse();
+    expect($lab->fresh()->always_remote_access)->toBeTrue();
 });
 
 // Helpers

--- a/tests/Feature/LabTest.php
+++ b/tests/Feature/LabTest.php
@@ -9,8 +9,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('we can create a new lab', function () {
     $this->actingAs($this->createUser());

--- a/tests/Feature/LabTest.php
+++ b/tests/Feature/LabTest.php
@@ -5,10 +5,7 @@ use App\Livewire\LabNameEditor;
 use App\Livewire\NewLabEditor;
 use App\Models\Lab;
 use App\Models\Machine;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
-use Tests\TestCase;
-
 
 test('we can create a new lab', function () {
     $this->actingAs($this->createUser());

--- a/tests/Feature/LabTest.php
+++ b/tests/Feature/LabTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Livewire\LabList;
 use App\Livewire\LabNameEditor;
 use App\Livewire\NewLabEditor;
@@ -11,192 +9,175 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class LabTest extends TestCase
+uses(TestCase::class);
+uses(RefreshDatabase::class);
+
+test('we can create a new lab', function () {
+    $this->actingAs($this->createUser());
+    Livewire::test(NewLabEditor::class)
+        ->assertSee('Add new lab')
+        ->set('editing', true)
+        ->assertDontSee('Add new lab')
+        ->assertSee('Save')
+        ->set('labName', 'LABLAB')
+        ->set('school', 'Science')
+        ->call('saveLab')
+        ->assertSet('labName', '')
+        ->assertSet('editing', false)
+        ->assertDispatched('labAdded');
+    $this->assertEquals('LABLAB', Lab::first()->name);
+    $this->assertEquals('Science', Lab::first()->school);
+});
+
+test('we can delete an existing lab', function () {
+    $this->actingAs($this->createUser());
+    $lab = createLab('My Amazing Lab');
+
+    Livewire::test(LabNameEditor::class, ['lab' => $lab])
+        ->assertSee($lab->name)
+        ->set('editing', true)
+        ->assertSee('Delete')
+        ->call('deleteLab')
+        ->assertDontSee('Delete')
+        ->assertSee('Confirm')
+        ->call('deleteLab');
+    $this->assertCount(0, Lab::all());
+});
+
+test('we can add machine ips to a lab', function () {
+    $this->actingAs($this->createUser());
+    $lab = createLab('blah');
+
+    $response = $this->post(route('lab.members.update', $lab->id), [
+        'ips' => "127.0.0.1\r\n1.2.3.4\r\n",
+    ]);
+
+    $response->assertRedirect(route('lab.show', $lab->id));
+    tap($lab->fresh(), function ($lab) {
+        $this->assertCount(2, $lab->members);
+        $this->assertTrue($lab->members->contains('ip', '1.2.3.4'));
+        $this->assertTrue($lab->members->contains('ip', '127.0.0.1'));
+    });
+});
+
+test('sending a list of labmember ips removes any not on the list', function () {
+    $this->withoutExceptionHandling();
+    $this->actingAs($this->createUser());
+    $lab = createLab('blah');
+    $machine1 = Machine::factory()->create(['ip' => '1.2.3.4', 'lab_id' => $lab->id]);
+    $machine2 = Machine::factory()->create(['ip' => '127.0.0.1', 'lab_id' => $lab->id]);
+    $response = $this->post(route('lab.members.update', $lab->id), [
+        'ips' => "127.0.0.1\r\n1.0.3.4\r\n",
+    ]);
+
+    $response->assertRedirect(route('lab.show', $lab->id));
+    tap($lab->fresh(), function ($lab) {
+        $this->assertCount(2, $lab->members);
+        $this->assertTrue($lab->members->contains('ip', '1.0.3.4'));
+        $this->assertTrue($lab->members->contains('ip', '127.0.0.1'));
+    });
+});
+
+test('blank lines in the list of ips are ignored', function () {
+    $this->withoutExceptionHandling();
+    $this->actingAs($this->createUser());
+    $lab = createLab('blah');
+    $machine1 = Machine::factory()->create(['ip' => '1.2.3.4', 'lab_id' => $lab->id]);
+    $machine2 = Machine::factory()->create(['ip' => '127.0.0.1', 'lab_id' => $lab->id]);
+    $response = $this->post(route('lab.members.update', $lab->id), [
+        'ips' => "127.0.0.1\r\n\r\n\r\n1.0.3.4\r\n\r\n\r\n",
+    ]);
+
+    $response->assertRedirect(route('lab.show', $lab->id));
+    tap($lab->fresh(), function ($lab) {
+        $this->assertCount(2, $lab->members);
+        $this->assertTrue($lab->members->contains('ip', '1.0.3.4'));
+        $this->assertTrue($lab->members->contains('ip', '127.0.0.1'));
+    });
+});
+
+test('invalid ips are ignored', function () {
+    $this->withoutExceptionHandling();
+    $this->actingAs($this->createUser());
+    $lab = createLab('blah');
+    $machine1 = Machine::factory()->create(['ip' => '1.2.3.4', 'lab_id' => $lab->id]);
+    $machine2 = Machine::factory()->create(['ip' => '127.0.0.1', 'lab_id' => $lab->id]);
+    $response = $this->post(route('lab.members.update', $lab->id), [
+        'ips' => "fred\r\n\r\n\r\n1.0.3.4\r\n\r\n\r\n",
+    ]);
+
+    $response->assertRedirect(route('lab.show', $lab->id));
+    tap($lab->fresh(), function ($lab) {
+        $this->assertCount(1, $lab->members);
+        $this->assertTrue($lab->members->contains('ip', '1.0.3.4'));
+    });
+});
+
+test('we can toggle a labs availability for remote access', function () {
+    $this->withoutExceptionHandling();
+    $this->actingAs($this->createUser());
+    $lab = createLab('blah');
+    $lab->always_remote_access = false;
+    $lab->limited_remote_access = false;
+    $lab->save();
+
+    $this->assertFalse($lab->limited_remote_access);
+    $this->assertFalse($lab->always_remote_access);
+
+    Livewire::test(LabList::class)
+        ->assertSee($lab->name)
+        ->call('toggleLimitedRemote', $lab->id);
+
+    $this->assertTrue($lab->fresh()->limited_remote_access);
+    $this->assertFalse($lab->fresh()->always_remote_access);
+
+    Livewire::test(LabList::class)
+        ->assertSee($lab->name)
+        ->call('toggleLimitedRemote', $lab->id);
+
+    $this->assertFalse($lab->fresh()->limited_remote_access);
+    $this->assertFalse($lab->fresh()->always_remote_access);
+
+    Livewire::test(LabList::class)
+        ->assertSee($lab->name)
+        ->call('toggleAlwaysRemote', $lab->id);
+
+    $this->assertFalse($lab->fresh()->limited_remote_access);
+    $this->assertTrue($lab->fresh()->always_remote_access);
+
+    Livewire::test(LabList::class)
+        ->assertSee($lab->name)
+        ->call('toggleAlwaysRemote', $lab->id);
+
+    $this->assertFalse($lab->fresh()->limited_remote_access);
+    $this->assertFalse($lab->fresh()->always_remote_access);
+});
+
+test('a lab cannot be both limited and unlimited access at the same time', function () {
+    $this->withoutExceptionHandling();
+    $this->actingAs($this->createUser());
+    $lab = createLab('blah');
+    $lab->always_remote_access = true;
+    $lab->limited_remote_access = false;
+    $lab->save();
+
+    Livewire::test(LabList::class)
+        ->assertSee($lab->name)
+        ->call('toggleLimitedRemote', $lab->id);
+
+    $this->assertTrue($lab->fresh()->limited_remote_access);
+    $this->assertFalse($lab->fresh()->always_remote_access);
+
+    Livewire::test(LabList::class)
+        ->assertSee($lab->name)
+        ->call('toggleAlwaysRemote', $lab->id);
+
+    $this->assertFalse($lab->fresh()->limited_remote_access);
+    $this->assertTrue($lab->fresh()->always_remote_access);
+});
+
+// Helpers
+function createLab($name = 'whatevs')
 {
-    use RefreshDatabase;
-
-    /** @test */
-    public function we_can_create_a_new_lab(): void
-    {
-        $this->actingAs($this->createUser());
-        Livewire::test(NewLabEditor::class)
-            ->assertSee('Add new lab')
-            ->set('editing', true)
-            ->assertDontSee('Add new lab')
-            ->assertSee('Save')
-            ->set('labName', 'LABLAB')
-            ->set('school', 'Science')
-            ->call('saveLab')
-            ->assertSet('labName', '')
-            ->assertSet('editing', false)
-            ->assertDispatched('labAdded');
-        $this->assertEquals('LABLAB', Lab::first()->name);
-        $this->assertEquals('Science', Lab::first()->school);
-    }
-
-    /** @test */
-    public function we_can_delete_an_existing_lab(): void
-    {
-        $this->actingAs($this->createUser());
-        $lab = $this->createLab('My Amazing Lab');
-
-        Livewire::test(LabNameEditor::class, ['lab' => $lab])
-            ->assertSee($lab->name)
-            ->set('editing', true)
-            ->assertSee('Delete')
-            ->call('deleteLab')
-            ->assertDontSee('Delete')
-            ->assertSee('Confirm')
-            ->call('deleteLab');
-        $this->assertCount(0, Lab::all());
-    }
-
-    /** @test */
-    public function we_can_add_machine_ips_to_a_lab(): void
-    {
-        $this->actingAs($this->createUser());
-        $lab = $this->createLab('blah');
-
-        $response = $this->post(route('lab.members.update', $lab->id), [
-            'ips' => "127.0.0.1\r\n1.2.3.4\r\n",
-        ]);
-
-        $response->assertRedirect(route('lab.show', $lab->id));
-        tap($lab->fresh(), function ($lab) {
-            $this->assertCount(2, $lab->members);
-            $this->assertTrue($lab->members->contains('ip', '1.2.3.4'));
-            $this->assertTrue($lab->members->contains('ip', '127.0.0.1'));
-        });
-    }
-
-    /** @test */
-    public function sending_a_list_of_labmember_ips_removes_any_not_on_the_list(): void
-    {
-        $this->withoutExceptionHandling();
-        $this->actingAs($this->createUser());
-        $lab = $this->createLab('blah');
-        $machine1 = Machine::factory()->create(['ip' => '1.2.3.4', 'lab_id' => $lab->id]);
-        $machine2 = Machine::factory()->create(['ip' => '127.0.0.1', 'lab_id' => $lab->id]);
-        $response = $this->post(route('lab.members.update', $lab->id), [
-            'ips' => "127.0.0.1\r\n1.0.3.4\r\n",
-        ]);
-
-        $response->assertRedirect(route('lab.show', $lab->id));
-        tap($lab->fresh(), function ($lab) {
-            $this->assertCount(2, $lab->members);
-            $this->assertTrue($lab->members->contains('ip', '1.0.3.4'));
-            $this->assertTrue($lab->members->contains('ip', '127.0.0.1'));
-        });
-    }
-
-    /** @test */
-    public function blank_lines_in_the_list_of_ips_are_ignored(): void
-    {
-        $this->withoutExceptionHandling();
-        $this->actingAs($this->createUser());
-        $lab = $this->createLab('blah');
-        $machine1 = Machine::factory()->create(['ip' => '1.2.3.4', 'lab_id' => $lab->id]);
-        $machine2 = Machine::factory()->create(['ip' => '127.0.0.1', 'lab_id' => $lab->id]);
-        $response = $this->post(route('lab.members.update', $lab->id), [
-            'ips' => "127.0.0.1\r\n\r\n\r\n1.0.3.4\r\n\r\n\r\n",
-        ]);
-
-        $response->assertRedirect(route('lab.show', $lab->id));
-        tap($lab->fresh(), function ($lab) {
-            $this->assertCount(2, $lab->members);
-            $this->assertTrue($lab->members->contains('ip', '1.0.3.4'));
-            $this->assertTrue($lab->members->contains('ip', '127.0.0.1'));
-        });
-    }
-
-    /** @test */
-    public function invalid_ips_are_ignored(): void
-    {
-        $this->withoutExceptionHandling();
-        $this->actingAs($this->createUser());
-        $lab = $this->createLab('blah');
-        $machine1 = Machine::factory()->create(['ip' => '1.2.3.4', 'lab_id' => $lab->id]);
-        $machine2 = Machine::factory()->create(['ip' => '127.0.0.1', 'lab_id' => $lab->id]);
-        $response = $this->post(route('lab.members.update', $lab->id), [
-            'ips' => "fred\r\n\r\n\r\n1.0.3.4\r\n\r\n\r\n",
-        ]);
-
-        $response->assertRedirect(route('lab.show', $lab->id));
-        tap($lab->fresh(), function ($lab) {
-            $this->assertCount(1, $lab->members);
-            $this->assertTrue($lab->members->contains('ip', '1.0.3.4'));
-        });
-    }
-
-    /** @test */
-    public function we_can_toggle_a_labs_availability_for_remote_access(): void
-    {
-        $this->withoutExceptionHandling();
-        $this->actingAs($this->createUser());
-        $lab = $this->createLab('blah');
-        $lab->always_remote_access = false;
-        $lab->limited_remote_access = false;
-        $lab->save();
-
-        $this->assertFalse($lab->limited_remote_access);
-        $this->assertFalse($lab->always_remote_access);
-
-        Livewire::test(LabList::class)
-            ->assertSee($lab->name)
-            ->call('toggleLimitedRemote', $lab->id);
-
-        $this->assertTrue($lab->fresh()->limited_remote_access);
-        $this->assertFalse($lab->fresh()->always_remote_access);
-
-        Livewire::test(LabList::class)
-            ->assertSee($lab->name)
-            ->call('toggleLimitedRemote', $lab->id);
-
-        $this->assertFalse($lab->fresh()->limited_remote_access);
-        $this->assertFalse($lab->fresh()->always_remote_access);
-
-        Livewire::test(LabList::class)
-            ->assertSee($lab->name)
-            ->call('toggleAlwaysRemote', $lab->id);
-
-        $this->assertFalse($lab->fresh()->limited_remote_access);
-        $this->assertTrue($lab->fresh()->always_remote_access);
-
-        Livewire::test(LabList::class)
-            ->assertSee($lab->name)
-            ->call('toggleAlwaysRemote', $lab->id);
-
-        $this->assertFalse($lab->fresh()->limited_remote_access);
-        $this->assertFalse($lab->fresh()->always_remote_access);
-    }
-
-    /** @test */
-    public function a_lab_cannot_be_both_limited_and_unlimited_access_at_the_same_time(): void
-    {
-        $this->withoutExceptionHandling();
-        $this->actingAs($this->createUser());
-        $lab = $this->createLab('blah');
-        $lab->always_remote_access = true;
-        $lab->limited_remote_access = false;
-        $lab->save();
-
-        Livewire::test(LabList::class)
-            ->assertSee($lab->name)
-            ->call('toggleLimitedRemote', $lab->id);
-
-        $this->assertTrue($lab->fresh()->limited_remote_access);
-        $this->assertFalse($lab->fresh()->always_remote_access);
-
-        Livewire::test(LabList::class)
-            ->assertSee($lab->name)
-            ->call('toggleAlwaysRemote', $lab->id);
-
-        $this->assertFalse($lab->fresh()->limited_remote_access);
-        $this->assertTrue($lab->fresh()->always_remote_access);
-    }
-
-    protected function createLab($name = 'whatevs')
-    {
-        return Lab::factory()->create(['name' => $name]);
-    }
+    return Lab::factory()->create(['name' => $name]);
 }

--- a/tests/Feature/MachineListTest.php
+++ b/tests/Feature/MachineListTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Lab;
 use App\Models\Machine;
 use App\Models\User;
@@ -9,123 +7,111 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-class MachineListTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    /** @test */
-    public function we_can_see_a_list_of_all_machines(): void
-    {
-        $this->withoutExceptionHandling();
-        $user = User::factory()->create(['is_allowed' => true]);
-        $machines = Machine::factory()->count(10)->create();
+test('we can see a list of all machines', function () {
+    $this->withoutExceptionHandling();
+    $user = User::factory()->create(['is_allowed' => true]);
+    $machines = Machine::factory()->count(10)->create();
 
-        $response = $this->actingAs($user)->get(route('machine.index'));
+    $response = $this->actingAs($user)->get(route('machine.index'));
 
-        $response->assertOk();
-        $machines->each(function ($machine) use ($response) {
-            $response->assertSee($machine->name);
-        });
-    }
+    $response->assertOk();
+    $machines->each(function ($machine) use ($response) {
+        $response->assertSee($machine->name);
+    });
+});
 
-    /** @test */
-    public function we_can_see_a_list_of_all_machines_for_a_specific_lab(): void
-    {
-        $user = User::factory()->create(['is_allowed' => true]);
-        $lab = Lab::factory()->create();
-        $labMachines = Machine::factory()->count(3)->create(['lab_id' => $lab->id]);
-        $otherMachines = Machine::factory()->count(3)->create(['lab_id' => null]);
+test('we can see a list of all machines for a specific lab', function () {
+    $user = User::factory()->create(['is_allowed' => true]);
+    $lab = Lab::factory()->create();
+    $labMachines = Machine::factory()->count(3)->create(['lab_id' => $lab->id]);
+    $otherMachines = Machine::factory()->count(3)->create(['lab_id' => null]);
 
-        $response = $this->actingAs($user)->get(route('lab.show', $lab->id));
+    $response = $this->actingAs($user)->get(route('lab.show', $lab->id));
 
-        $response->assertOk();
-        $labMachines->each(function ($machine) use ($response) {
-            $response->assertSee($machine->name);
-        });
-        $otherMachines->each(function ($machine) use ($response) {
-            $response->assertDontSee($machine->name);
-        });
-    }
+    $response->assertOk();
+    $labMachines->each(function ($machine) use ($response) {
+        $response->assertSee($machine->name);
+    });
+    $otherMachines->each(function ($machine) use ($response) {
+        $response->assertDontSee($machine->name);
+    });
+});
 
-    /** @test */
-    public function we_can_filter_the_list_of_machines_by_name_or_ip_address(): void
-    {
-        $user = User::factory()->create(['is_allowed' => true]);
-        $machine1 = Machine::factory()->create(['name' => 'test.example.com', 'ip' => '1.1.1.1']);
-        $machine2 = Machine::factory()->create(['name' => 'jenny.something.org', 'ip' => '2.2.2.2']);
+test('we can filter the list of machines by name or ip address', function () {
+    $user = User::factory()->create(['is_allowed' => true]);
+    $machine1 = Machine::factory()->create(['name' => 'test.example.com', 'ip' => '1.1.1.1']);
+    $machine2 = Machine::factory()->create(['name' => 'jenny.something.org', 'ip' => '2.2.2.2']);
 
-        $this->actingAs($user);
+    $this->actingAs($user);
 
-        Livewire::test('machine-list', ['machines' => [$machine1, $machine2]])
-            ->assertSee('test.example.com')
-            ->assertSee('jenny.something.org')
-            ->set('filter', 'test')
-            ->assertSee('test.example.com')
-            ->assertDontSee('jenny.something.org')
-            ->set('filter', '2.2.2')
-            ->assertDontSee('test.example.com')
-            ->assertSee('jenny.something.org');
-    }
+    Livewire::test('machine-list', ['machines' => [$machine1, $machine2]])
+        ->assertSee('test.example.com')
+        ->assertSee('jenny.something.org')
+        ->set('filter', 'test')
+        ->assertSee('test.example.com')
+        ->assertDontSee('jenny.something.org')
+        ->set('filter', '2.2.2')
+        ->assertDontSee('test.example.com')
+        ->assertSee('jenny.something.org');
+});
 
-    /** @test */
-    public function we_can_optionally_filter_the_list_of_machines_by_meta_data(): void
-    {
-        $user = User::factory()->create(['is_allowed' => true]);
-        $machine1 = Machine::factory()->create(['name' => 'test.example.com', 'ip' => '1.1.1.1', 'meta' => 'blah']);
-        $machine2 = Machine::factory()->create(['name' => 'jenny.something.org', 'ip' => '2.2.2.2', 'meta' => 'spoons']);
+test('we can optionally filter the list of machines by meta data', function () {
+    $user = User::factory()->create(['is_allowed' => true]);
+    $machine1 = Machine::factory()->create(['name' => 'test.example.com', 'ip' => '1.1.1.1', 'meta' => 'blah']);
+    $machine2 = Machine::factory()->create(['name' => 'jenny.something.org', 'ip' => '2.2.2.2', 'meta' => 'spoons']);
 
-        $this->actingAs($user);
+    $this->actingAs($user);
 
-        Livewire::test('machine-list', ['machines' => [$machine1, $machine2]])
-            ->assertSee('test.example.com')
-            ->assertSee('jenny.something.org')
-            ->set('filter', 'spoons')
-            ->assertDontSee('test.example.com')
-            ->assertDontSee('jenny.something.org')
-            ->set('includeMeta', true)
-            ->assertSee('jenny.something.org');
-    }
+    Livewire::test('machine-list', ['machines' => [$machine1, $machine2]])
+        ->assertSee('test.example.com')
+        ->assertSee('jenny.something.org')
+        ->set('filter', 'spoons')
+        ->assertDontSee('test.example.com')
+        ->assertDontSee('jenny.something.org')
+        ->set('includeMeta', true)
+        ->assertSee('jenny.something.org');
+});
 
-    /** @test */
-    public function we_can_filter_the_list_of_machines_by_their_status(): void
-    {
-        $user = User::factory()->create(['is_allowed' => true]);
-        $machine1 = Machine::factory()->create(['name' => 'test.example.com', 'is_locked' => true, 'logged_in' => false]);
-        $machine2 = Machine::factory()->create(['name' => 'jenny.something.org', 'is_locked' => false, 'logged_in' => false]);
-        $machine3 = Machine::factory()->create(['name' => 'cat.example.com', 'is_locked' => false, 'logged_in' => true]);
-        $machine4 = Machine::factory()->create(['name' => 'dog.something.org', 'is_locked' => false, 'logged_in' => false]);
+test('we can filter the list of machines by their status', function () {
+    $user = User::factory()->create(['is_allowed' => true]);
+    $machine1 = Machine::factory()->create(['name' => 'test.example.com', 'is_locked' => true, 'logged_in' => false]);
+    $machine2 = Machine::factory()->create(['name' => 'jenny.something.org', 'is_locked' => false, 'logged_in' => false]);
+    $machine3 = Machine::factory()->create(['name' => 'cat.example.com', 'is_locked' => false, 'logged_in' => true]);
+    $machine4 = Machine::factory()->create(['name' => 'dog.something.org', 'is_locked' => false, 'logged_in' => false]);
 
-        $this->actingAs($user);
+    $this->actingAs($user);
 
-        Livewire::test('machine-list', ['machines' => [$machine1, $machine2, $machine3, $machine4]])
-            ->assertSee('test.example.com')
-            ->assertSee('jenny.something.org')
-            ->assertSee('cat.example.com')
-            ->assertSee('dog.something.org')
-            ->set('statusFilter', 'locked')
-            ->assertSee('test.example.com')
-            ->assertDontSee('jenny.something.org')
-            ->assertDontSee('cat.example.com')
-            ->assertDontSee('dog.something.org')
-            ->set('statusFilter', 'not_locked')
-            ->assertDontSee('test.example.com')
-            ->assertSee('jenny.something.org')
-            ->assertSee('cat.example.com')
-            ->assertSee('dog.something.org')
-            ->set('statusFilter', 'logged_in')
-            ->assertDontSee('test.example.com')
-            ->assertDontSee('jenny.something.org')
-            ->assertSee('cat.example.com')
-            ->assertDontSee('dog.something.org')
-            ->set('statusFilter', 'not_logged_in')
-            ->assertSee('test.example.com')
-            ->assertSee('jenny.something.org')
-            ->assertDontSee('cat.example.com')
-            ->assertSee('dog.something.org')
-            ->set('statusFilter', '')
-            ->assertSee('test.example.com')
-            ->assertSee('jenny.something.org')
-            ->assertSee('cat.example.com')
-            ->assertSee('dog.something.org');
-    }
-}
+    Livewire::test('machine-list', ['machines' => [$machine1, $machine2, $machine3, $machine4]])
+        ->assertSee('test.example.com')
+        ->assertSee('jenny.something.org')
+        ->assertSee('cat.example.com')
+        ->assertSee('dog.something.org')
+        ->set('statusFilter', 'locked')
+        ->assertSee('test.example.com')
+        ->assertDontSee('jenny.something.org')
+        ->assertDontSee('cat.example.com')
+        ->assertDontSee('dog.something.org')
+        ->set('statusFilter', 'not_locked')
+        ->assertDontSee('test.example.com')
+        ->assertSee('jenny.something.org')
+        ->assertSee('cat.example.com')
+        ->assertSee('dog.something.org')
+        ->set('statusFilter', 'logged_in')
+        ->assertDontSee('test.example.com')
+        ->assertDontSee('jenny.something.org')
+        ->assertSee('cat.example.com')
+        ->assertDontSee('dog.something.org')
+        ->set('statusFilter', 'not_logged_in')
+        ->assertSee('test.example.com')
+        ->assertSee('jenny.something.org')
+        ->assertDontSee('cat.example.com')
+        ->assertSee('dog.something.org')
+        ->set('statusFilter', '')
+        ->assertSee('test.example.com')
+        ->assertSee('jenny.something.org')
+        ->assertSee('cat.example.com')
+        ->assertSee('dog.something.org');
+});

--- a/tests/Feature/MachineListTest.php
+++ b/tests/Feature/MachineListTest.php
@@ -3,10 +3,7 @@
 use App\Models\Lab;
 use App\Models\Machine;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
-use Tests\TestCase;
-
 
 test('we can see a list of all machines', function () {
     $this->withoutExceptionHandling();

--- a/tests/Feature/MachineListTest.php
+++ b/tests/Feature/MachineListTest.php
@@ -7,8 +7,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('we can see a list of all machines', function () {
     $this->withoutExceptionHandling();

--- a/tests/Feature/OptionsTest.php
+++ b/tests/Feature/OptionsTest.php
@@ -4,8 +4,6 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('we can see the options page', function () {
     $this->withoutExceptionHandling();

--- a/tests/Feature/OptionsTest.php
+++ b/tests/Feature/OptionsTest.php
@@ -1,65 +1,57 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class OptionsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    /** @test */
-    public function we_can_see_the_options_page(): void
-    {
-        $this->withoutExceptionHandling();
-        $user = $this->createUser();
-        $response = $this->actingAs($user)->get(route('options.edit'));
+test('we can see the options page', function () {
+    $this->withoutExceptionHandling();
+    $user = $this->createUser();
+    $response = $this->actingAs($user)->get(route('options.edit'));
 
-        $response->assertOk();
-        $response->assertSee('Options');
-    }
+    $response->assertOk();
+    $response->assertSee('Options');
+});
 
-    /** @test */
-    public function we_can_update_all_of_the_options(): void
-    {
-        $this->withoutExceptionHandling();
-        $user1 = User::factory()->create();
-        $user2 = User::factory()->create(['is_allowed' => true]);
-        $user3 = User::factory()->create();
-        $user4 = User::factory()->create(['is_allowed' => true]);
+test('we can update all of the options', function () {
+    $this->withoutExceptionHandling();
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create(['is_allowed' => true]);
+    $user3 = User::factory()->create();
+    $user4 = User::factory()->create(['is_allowed' => true]);
 
-        $this->assertFalse($user1->fresh()->isAllowedAccess());
-        $this->assertTrue($user2->fresh()->isAllowedAccess());
-        $this->assertFalse($user3->fresh()->isAllowedAccess());
-        $this->assertTrue($user4->fresh()->isAllowedAccess());
+    $this->assertFalse($user1->fresh()->isAllowedAccess());
+    $this->assertTrue($user2->fresh()->isAllowedAccess());
+    $this->assertFalse($user3->fresh()->isAllowedAccess());
+    $this->assertTrue($user4->fresh()->isAllowedAccess());
 
-        $response = $this->actingAs($user2)->post(route('options.update'), [
-            'remote-start-hour' => 20,
-            'remote-end-hour' => 10,
-            'remote-summer' => '04/Feb - 11/Mar',
-            'remote-xmas' => '04/Dec - 31/Dec',
-            'remote-easter' => '04/Apr - 10/Apr',
-            'allowed_guids' => "{$user1->username}\r\n{$user3->username}\r\n",
-        ]);
+    $response = $this->actingAs($user2)->post(route('options.update'), [
+        'remote-start-hour' => 20,
+        'remote-end-hour' => 10,
+        'remote-summer' => '04/Feb - 11/Mar',
+        'remote-xmas' => '04/Dec - 31/Dec',
+        'remote-easter' => '04/Apr - 10/Apr',
+        'allowed_guids' => "{$user1->username}\r\n{$user3->username}\r\n",
+    ]);
 
-        $response->assertRedirect('/');
-        $response->assertSessionDoesntHaveErrors();
-        $this->assertEquals('20', option('remote-start-hour'));
-        $this->assertEquals('10', option('remote-end-hour'));
-        $this->assertEquals('04/Feb', option('remote-start-summer'));
-        $this->assertEquals('11/Mar', option('remote-end-summer'));
-        $this->assertEquals('04/Dec', option('remote-start-xmas'));
-        $this->assertEquals('31/Dec', option('remote-end-xmas'));
-        $this->assertEquals('04/Apr', option('remote-start-easter'));
-        $this->assertEquals('10/Apr', option('remote-end-easter'));
-        $this->assertTrue($user1->fresh()->isAllowedAccess());
-        // note: users can't remove themselves from the permission list
-        // so user2 is still allowed access even though they weren't in
-        // the supplied allowed_guids
-        $this->assertTrue($user2->fresh()->isAllowedAccess());
-        $this->assertTrue($user3->fresh()->isAllowedAccess());
-        $this->assertFalse($user4->fresh()->isAllowedAccess());
-    }
-}
+    $response->assertRedirect('/');
+    $response->assertSessionDoesntHaveErrors();
+    $this->assertEquals('20', option('remote-start-hour'));
+    $this->assertEquals('10', option('remote-end-hour'));
+    $this->assertEquals('04/Feb', option('remote-start-summer'));
+    $this->assertEquals('11/Mar', option('remote-end-summer'));
+    $this->assertEquals('04/Dec', option('remote-start-xmas'));
+    $this->assertEquals('31/Dec', option('remote-end-xmas'));
+    $this->assertEquals('04/Apr', option('remote-start-easter'));
+    $this->assertEquals('10/Apr', option('remote-end-easter'));
+    $this->assertTrue($user1->fresh()->isAllowedAccess());
+    // note: users can't remove themselves from the permission list
+    // so user2 is still allowed access even though they weren't in
+    // the supplied allowed_guids
+    $this->assertTrue($user2->fresh()->isAllowedAccess());
+    $this->assertTrue($user3->fresh()->isAllowedAccess());
+    $this->assertFalse($user4->fresh()->isAllowedAccess());
+});

--- a/tests/Feature/OptionsTest.php
+++ b/tests/Feature/OptionsTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
 
 test('we can see the options page', function () {
     $this->withoutExceptionHandling();

--- a/tests/Feature/OptionsTest.php
+++ b/tests/Feature/OptionsTest.php
@@ -23,10 +23,10 @@ test('we can update all of the options', function () {
     $user3 = User::factory()->create();
     $user4 = User::factory()->create(['is_allowed' => true]);
 
-    $this->assertFalse($user1->fresh()->isAllowedAccess());
-    $this->assertTrue($user2->fresh()->isAllowedAccess());
-    $this->assertFalse($user3->fresh()->isAllowedAccess());
-    $this->assertTrue($user4->fresh()->isAllowedAccess());
+    expect($user1->fresh()->isAllowedAccess())->toBeFalse();
+    expect($user2->fresh()->isAllowedAccess())->toBeTrue();
+    expect($user3->fresh()->isAllowedAccess())->toBeFalse();
+    expect($user4->fresh()->isAllowedAccess())->toBeTrue();
 
     $response = $this->actingAs($user2)->post(route('options.update'), [
         'remote-start-hour' => 20,
@@ -39,19 +39,19 @@ test('we can update all of the options', function () {
 
     $response->assertRedirect('/');
     $response->assertSessionDoesntHaveErrors();
-    $this->assertEquals('20', option('remote-start-hour'));
-    $this->assertEquals('10', option('remote-end-hour'));
-    $this->assertEquals('04/Feb', option('remote-start-summer'));
-    $this->assertEquals('11/Mar', option('remote-end-summer'));
-    $this->assertEquals('04/Dec', option('remote-start-xmas'));
-    $this->assertEquals('31/Dec', option('remote-end-xmas'));
-    $this->assertEquals('04/Apr', option('remote-start-easter'));
-    $this->assertEquals('10/Apr', option('remote-end-easter'));
-    $this->assertTrue($user1->fresh()->isAllowedAccess());
+    expect(option('remote-start-hour'))->toEqual('20');
+    expect(option('remote-end-hour'))->toEqual('10');
+    expect(option('remote-start-summer'))->toEqual('04/Feb');
+    expect(option('remote-end-summer'))->toEqual('11/Mar');
+    expect(option('remote-start-xmas'))->toEqual('04/Dec');
+    expect(option('remote-end-xmas'))->toEqual('31/Dec');
+    expect(option('remote-start-easter'))->toEqual('04/Apr');
+    expect(option('remote-end-easter'))->toEqual('10/Apr');
+    expect($user1->fresh()->isAllowedAccess())->toBeTrue();
     // note: users can't remove themselves from the permission list
     // so user2 is still allowed access even though they weren't in
     // the supplied allowed_guids
-    $this->assertTrue($user2->fresh()->isAllowedAccess());
-    $this->assertTrue($user3->fresh()->isAllowedAccess());
-    $this->assertFalse($user4->fresh()->isAllowedAccess());
+    expect($user2->fresh()->isAllowedAccess())->toBeTrue();
+    expect($user3->fresh()->isAllowedAccess())->toBeTrue();
+    expect($user4->fresh()->isAllowedAccess())->toBeFalse();
 });

--- a/tests/Feature/StatsTest.php
+++ b/tests/Feature/StatsTest.php
@@ -1,28 +1,22 @@
 <?php
 
-namespace Tests\Feature;
-
 use App\Models\Lab;
 use App\Models\Machine;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class StatsTest extends TestCase
-{
-    use RefreshDatabase;
+uses(TestCase::class);
+uses(RefreshDatabase::class);
 
-    /** @test */
-    public function we_can_get_the_prometheus_metrics_stats(): void
-    {
-        $this->withoutExceptionHandling();
-        $labs = Lab::factory()->count(3)->create();
-        $labs->each(function ($lab) {
-            Machine::factory()->count(3)->create(['lab_id' => $lab->id]);
-        });
+test('we can get the prometheus metrics stats', function () {
+    $this->withoutExceptionHandling();
+    $labs = Lab::factory()->count(3)->create();
+    $labs->each(function ($lab) {
+        Machine::factory()->count(3)->create(['lab_id' => $lab->id]);
+    });
 
-        $response = $this->get('/metrics');
+    $response = $this->get('/metrics');
 
-        $response->assertOk();
-        $response->assertSee($labs->first()->name);
-    }
-}
+    $response->assertOk();
+    $response->assertSee($labs->first()->name);
+});

--- a/tests/Feature/StatsTest.php
+++ b/tests/Feature/StatsTest.php
@@ -5,8 +5,6 @@ use App\Models\Machine;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-uses(TestCase::class);
-uses(RefreshDatabase::class);
 
 test('we can get the prometheus metrics stats', function () {
     $this->withoutExceptionHandling();

--- a/tests/Feature/StatsTest.php
+++ b/tests/Feature/StatsTest.php
@@ -2,9 +2,6 @@
 
 use App\Models\Lab;
 use App\Models\Machine;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
 
 test('we can get the prometheus metrics stats', function () {
     $this->withoutExceptionHandling();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php
 
+uses(\Tests\TestCase::class)->in('Feature');
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class)->in('Feature');
+
 /*
 |--------------------------------------------------------------------------
 | Test Case

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/configuring-tests */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/custom-helpers */

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,16 +1,10 @@
 <?php
 
-namespace Tests\Unit;
 
-use PHPUnit\Framework\TestCase;
 
-class ExampleTest extends TestCase
-{
-    /**
-     * A basic test example.
-     */
-    public function testBasicTest(): void
-    {
-        $this->assertTrue(true);
-    }
-}
+/**
+ * A basic test example.
+ */
+test('basic test', function () {
+    $this->assertTrue(true);
+});

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -6,5 +6,5 @@
  * A basic test example.
  */
 test('basic test', function () {
-    $this->assertTrue(true);
+    expect(true)->toBeTrue();
 });


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-140132` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
